### PR TITLE
chore: Introduce `JSValue::new_string_inner` to simplify code

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -270,18 +270,10 @@ impl JSObject {
 
         if result.is_null() {
             return Err(JSException {
-                value: JSValue {
-                    raw: unsafe {
-                        sys::JSValueMakeString(
-                            context,
-                            JSString::from(
-                                "Cannot call this object as a function: it is not a valid function",
-                            )
-                            .raw,
-                        )
-                    },
-                    ctx: context,
-                },
+                value: JSValue::new_string_inner(
+                    context,
+                    "Cannot call this object as a function: it is not a valid function",
+                ),
             });
         }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -114,9 +114,16 @@ impl JSValue {
     /// assert!(v.is_string());
     /// ```
     pub fn new_string<S: Into<JSString>>(ctx: &JSContext, string: S) -> Self {
+        Self::new_string_inner(ctx.raw, string)
+    }
+
+    pub(crate) fn new_string_inner<S: Into<JSString>>(
+        ctx: *const sys::OpaqueJSContext,
+        string: S,
+    ) -> Self {
         JSValue {
-            raw: unsafe { sys::JSValueMakeString(ctx.raw, string.into().raw) },
-            ctx: ctx.raw,
+            raw: unsafe { sys::JSValueMakeString(ctx, string.into().raw) },
+            ctx,
         }
     }
 


### PR DESCRIPTION
This patch introduces `JSValue::new_string_inner` to construct a string with a context as a `*const OpaqueJSContext` instead of a `&JSContext`.

This new method helps to simplify another part of the code where a JS string was built manually.