### PR TITLE
feat: Implement `JSValue::new_array` and other small clean up

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -53,9 +53,7 @@ pub fn evaluate_script<S: Into<JSString>, U: Into<JSString>>(
         );
 
         if result.is_null() {
-            Err(JSException {
-                value: JSValue::new_inner(ctx.raw, exception),
-            })
+            Err(JSValue::new_inner(ctx.raw, exception).into())
         } else {
             Ok(JSValue::new_inner(ctx.raw, result))
         }
@@ -106,9 +104,7 @@ pub fn check_script_syntax<S: Into<JSString>, U: Into<JSString>>(
         if result {
             Ok(())
         } else {
-            Err(JSException {
-                value: JSValue::new_inner(ctx.raw, exception),
-            })
+            Err(JSValue::new_inner(ctx.raw, exception).into())
         }
     }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -42,27 +42,22 @@ pub fn evaluate_script<S: Into<JSString>, U: Into<JSString>>(
     starting_line_number: i32,
 ) -> Result<JSValue, JSException> {
     unsafe {
-        let mut e: sys::JSValueRef = ptr::null_mut();
-        let r = sys::JSEvaluateScript(
+        let mut exception: sys::JSValueRef = ptr::null_mut();
+        let result = sys::JSEvaluateScript(
             ctx.raw,
             script.into().raw,
             this_object.map(|t| t.raw).unwrap_or(ptr::null_mut()),
             source_url.into().raw,
             starting_line_number,
-            &mut e,
+            &mut exception,
         );
-        if r.is_null() {
+
+        if result.is_null() {
             Err(JSException {
-                value: JSValue {
-                    raw: e,
-                    ctx: ctx.raw,
-                },
+                value: JSValue::new_inner(ctx.raw, exception),
             })
         } else {
-            Ok(JSValue {
-                raw: r,
-                ctx: ctx.raw,
-            })
+            Ok(JSValue::new_inner(ctx.raw, result))
         }
     }
 }
@@ -99,22 +94,20 @@ pub fn check_script_syntax<S: Into<JSString>, U: Into<JSString>>(
     starting_line_number: i32,
 ) -> Result<(), JSException> {
     unsafe {
-        let mut e: sys::JSValueRef = ptr::null_mut();
-        let r = sys::JSCheckScriptSyntax(
+        let mut exception: sys::JSValueRef = ptr::null_mut();
+        let result = sys::JSCheckScriptSyntax(
             ctx.raw,
             script.into().raw,
             source_url.into().raw,
             starting_line_number,
-            &mut e,
+            &mut exception,
         );
-        if r {
+
+        if result {
             Ok(())
         } else {
             Err(JSException {
-                value: JSValue {
-                    raw: e,
-                    ctx: ctx.raw,
-                },
+                value: JSValue::new_inner(ctx.raw, exception),
             })
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -103,18 +103,12 @@ impl JSContext {
 
         if global_object.is_null() {
             Err(JSException {
-                value: JSValue {
-                    raw: global_object,
-                    ctx: self.raw,
-                },
+                value: JSValue::new_inner(self.raw, global_object),
             })
         } else {
             Ok(JSObject {
                 raw: global_object,
-                value: JSValue {
-                    raw: global_object,
-                    ctx: self.raw,
-                },
+                value: JSValue::new_inner(self.raw, global_object),
             })
         }
     }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -22,3 +22,9 @@ impl JSException {
             .as_string()
     }
 }
+
+impl From<JSValue> for JSException {
+    fn from(value: JSValue) -> Self {
+        Self { value }
+    }
+}

--- a/src/object.rs
+++ b/src/object.rs
@@ -76,13 +76,12 @@ impl JSObject {
     where
         S: Into<JSString>,
     {
-        let mut e: sys::JSValueRef = ptr::null_mut();
-        let v =
-            unsafe { sys::JSObjectGetProperty(self.value.ctx, self.raw, name.into().raw, &mut e) };
-        JSValue {
-            raw: v,
-            ctx: self.value.ctx,
-        }
+        let mut exception: sys::JSValueRef = ptr::null_mut();
+        let value = unsafe {
+            sys::JSObjectGetProperty(self.value.ctx, self.raw, name.into().raw, &mut exception)
+        };
+
+        JSValue::new_inner(self.value.ctx, value)
     }
 
     /// Gets a property from an object by numeric index.
@@ -126,12 +125,12 @@ impl JSObject {
     /// assert_eq!(o.get_property_at_index(2).as_string().expect("string"), "abc");
     /// ```
     pub fn get_property_at_index(&self, index: u32) -> JSValue {
-        let mut e: sys::JSValueRef = ptr::null_mut();
-        let v = unsafe { sys::JSObjectGetPropertyAtIndex(self.value.ctx, self.raw, index, &mut e) };
-        JSValue {
-            raw: v,
-            ctx: self.value.ctx,
-        }
+        let mut exception: sys::JSValueRef = ptr::null_mut();
+        let value = unsafe {
+            sys::JSObjectGetPropertyAtIndex(self.value.ctx, self.raw, index, &mut exception)
+        };
+
+        JSValue::new_inner(self.value.ctx, value)
     }
 
     /// Set a property onto an object.
@@ -170,10 +169,7 @@ impl JSObject {
 
         if !exception.is_null() {
             return Err(JSException {
-                value: JSValue {
-                    raw: exception,
-                    ctx: context,
-                },
+                value: JSValue::new_inner(context, exception),
             });
         }
 
@@ -210,10 +206,7 @@ impl JSObject {
 
         if !exception.is_null() {
             return Err(JSException {
-                value: JSValue {
-                    raw: exception,
-                    ctx: context,
-                },
+                value: JSValue::new_inner(context, exception),
             });
         }
 
@@ -261,10 +254,7 @@ impl JSObject {
 
         if !exception.is_null() {
             return Err(JSException {
-                value: JSValue {
-                    raw: exception,
-                    ctx: context,
-                },
+                value: JSValue::new_inner(context, exception),
             });
         }
 
@@ -277,10 +267,7 @@ impl JSObject {
             });
         }
 
-        Ok(JSValue {
-            raw: result,
-            ctx: context,
-        })
+        Ok(JSValue::new_inner(context, result))
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -168,9 +168,7 @@ impl JSObject {
         }
 
         if !exception.is_null() {
-            return Err(JSException {
-                value: JSValue::new_inner(context, exception),
-            });
+            return Err(JSValue::new_inner(context, exception).into());
         }
 
         Ok(())
@@ -205,9 +203,7 @@ impl JSObject {
         }
 
         if !exception.is_null() {
-            return Err(JSException {
-                value: JSValue::new_inner(context, exception),
-            });
+            return Err(JSValue::new_inner(context, exception).into());
         }
 
         Ok(())
@@ -253,18 +249,15 @@ impl JSObject {
         };
 
         if !exception.is_null() {
-            return Err(JSException {
-                value: JSValue::new_inner(context, exception),
-            });
+            return Err(JSValue::new_inner(context, exception).into());
         }
 
         if result.is_null() {
-            return Err(JSException {
-                value: JSValue::new_string_inner(
-                    context,
-                    "Cannot call this object as a function: it is not a valid function",
-                ),
-            });
+            return Err(JSValue::new_string_inner(
+                context,
+                "Cannot call this object as a function: it is not a valid function",
+            )
+            .into());
         }
 
         Ok(JSValue::new_inner(context, result))

--- a/src/value.rs
+++ b/src/value.rs
@@ -150,7 +150,17 @@ impl JSValue {
     /// * `ctx`: The execution context to use.
     /// * `items`: The array items as [`JSValue`]s.
     ///
-    /// Returns a `JSValue` of the `array` type, other an exception.
+    /// Returns a `JSValue` of the `array` type, otherwise an exception.
+    ///
+    /// ```
+    /// # use javascriptcore::{JSContext, JSValue};
+    /// let ctx = JSContext::default();
+    /// let value = JSValue::new_array(
+    ///     &ctx,
+    ///     &[JSValue::new_number(&ctx, 1.), JSValue::new_number(&ctx, 2.)]
+    /// ).unwrap();
+    /// assert!(value.is_array());
+    /// ```
     pub fn new_array(ctx: &JSContext, items: &[JSValue]) -> Result<Self, JSException> {
         let items = items
             .iter()

--- a/src/value.rs
+++ b/src/value.rs
@@ -168,15 +168,11 @@ impl JSValue {
         };
 
         if !exception.is_null() {
-            return Err(JSException {
-                value: JSValue::new_inner(ctx.raw, exception),
-            });
+            return Err(JSValue::new_inner(ctx.raw, exception).into());
         }
 
         if result.is_null() {
-            return Err(JSException {
-                value: JSValue::new_string(ctx, "Failed to make a new array"),
-            });
+            return Err(JSValue::new_string(ctx, "Failed to make a new array").into());
         }
 
         Ok(JSValue::new_inner(ctx.raw, result))
@@ -231,9 +227,7 @@ impl JSValue {
             unsafe { sys::JSValueCreateJSONString(self.ctx, self.raw, indent, &mut exception) };
 
         if value.is_null() {
-            Err(JSException {
-                value: JSValue::new_inner(self.ctx, exception),
-            })
+            Err(JSValue::new_inner(self.ctx, exception).into())
         } else {
             Ok(JSString { raw: value })
         }
@@ -434,9 +428,7 @@ impl JSValue {
         let number = unsafe { sys::JSValueToNumber(self.ctx, self.raw, &mut exception) };
 
         if number.is_nan() {
-            Err(JSException {
-                value: JSValue::new_inner(self.ctx, exception),
-            })
+            Err(JSValue::new_inner(self.ctx, exception).into())
         } else {
             Ok(number)
         }
@@ -460,9 +452,7 @@ impl JSValue {
         let string = unsafe { sys::JSValueToStringCopy(self.ctx, self.raw, &mut exception) };
 
         if string.is_null() {
-            Err(JSException {
-                value: JSValue::new_inner(self.ctx, exception),
-            })
+            Err(JSValue::new_inner(self.ctx, exception).into())
         } else {
             Ok(JSString { raw: string })
         }
@@ -486,9 +476,7 @@ impl JSValue {
         let object = unsafe { sys::JSValueToObject(self.ctx, self.raw, &mut exception) };
 
         if object.is_null() {
-            Err(JSException {
-                value: JSValue::new_inner(self.ctx, exception),
-            })
+            Err(JSValue::new_inner(self.ctx, exception).into())
         } else {
             Ok(JSObject {
                 raw: object,

--- a/src/value.rs
+++ b/src/value.rs
@@ -97,7 +97,7 @@ impl JSValue {
         }
     }
 
-    /// Creates a JavaScript value of the string type.
+    /// Creates a JavaScript value of the `string` type.
     ///
     /// * `ctx`: The execution context to use.
     /// * `string`: A value that can be converted into a [`JSString`] to assign
@@ -127,7 +127,7 @@ impl JSValue {
         }
     }
 
-    /// Creates a JavaScript value of the symbol type.
+    /// Creates a JavaScript value of the `symbol` type.
     ///
     /// * `ctx`: The execution context to use.
     /// * `description`: A value that can be converted into a [`JSString`] to


### PR DESCRIPTION
~~Built on top of #16.~~

This PR should ideally be reviewed commit-by-commit for a better experience.

Basically, it adds `JSValue::new_array`.
In addition, it adds `JSValue::new_inner` which simplify the code greatly.
Finally, it implements `From<JSValue>` for `JSException`, which adds another simplification of the code.