### PR TITLE
feat: Implement `JSValue::new_function`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["javascriptcore-sys"]
+members = ["javascriptcore-sys", "javascriptcore-macros"]
 
 [package]
 name = "javascriptcore"
@@ -17,4 +17,5 @@ categories = ["api-bindings"]
 exclude = ["javascript_core/**"]
 
 [dependencies]
+javascriptcore-macros = { path = "javascriptcore-macros", version = "0.0.1" }
 javascriptcore-sys = { path = "javascriptcore-sys", version = "0.0.5" }

--- a/javascriptcore-macros/Cargo.toml
+++ b/javascriptcore-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "javascriptcore-macros"
+version = "0.0.1"
+edition = "2021"
+authors = ["Bruce Mitchener <bruce.mitchener@gmail.com>", "Ivan Enderlin <ivan@mnt.io>"]
+license = "MIT OR Apache-2.0"
+description = "Procedural macros for the `javascriptcore` crate."
+keywords = ["javascript", "jsc", "scripting"]
+documentation = "https://docs.rs/javascriptcore-sys"
+homepage = "https://github.com/endoli/javascriptcore.rs"
+repository = "https://github.com/endoli/javascriptcore.rs"
+categories = ["external-ffi-bindings"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.33"
+syn = { version = "2.0.38", features = ["full"] }

--- a/javascriptcore-macros/src/lib.rs
+++ b/javascriptcore-macros/src/lib.rs
@@ -1,0 +1,71 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+#[proc_macro_attribute]
+pub fn function_callback(_attributes: TokenStream, item: TokenStream) -> TokenStream {
+    let function = syn::parse::<syn::ItemFn>(item)
+        .expect("#[function_callback] must apply on a valid function");
+    let function_name = &function.sig.ident;
+
+    quote! {
+        unsafe extern "C" fn #function_name(
+            __raw_ctx: javascriptcore_sys::JSContextRef,
+            __raw_function: javascriptcore_sys::JSObjectRef,
+            __raw_this_object: javascriptcore_sys::JSObjectRef,
+            __raw_argument_count: usize,
+            __raw_arguments: *const javascriptcore_sys::JSValueRef,
+            __raw_exception: *mut javascriptcore_sys::JSValueRef,
+        ) -> *const javascriptcore_sys::OpaqueJSValue {
+            use core::{mem, ptr, slice};
+            use javascriptcore::{JSContext, JSObject, JSValue};
+
+            let __ctx = JSContext::from_raw(__raw_ctx as *mut _);
+            let __function = JSObject::from_raw(__raw_ctx, __raw_function);
+            let __this_object = JSObject::from_raw(__raw_ctx, __raw_this_object);
+
+            let __function = if __raw_function.is_null() {
+                None
+            } else {
+                Some(&__function)
+            };
+
+            let __this_object = if __raw_this_object.is_null() {
+                None
+            } else {
+                Some(&__this_object)
+            };
+
+            let __arguments = if __raw_argument_count == 0 {
+                Vec::new()
+            } else {
+                unsafe { slice::from_raw_parts(__raw_arguments, __raw_argument_count) }
+                    .iter()
+                    .map(|value| JSValue::from_raw(__raw_ctx, *value))
+                    .collect::<Vec<_>>()
+            };
+
+            #function
+
+            let func: fn(
+                &JSContext,
+                Option<&JSObject>,
+                Option<&JSObject>,
+                arguments: &[JSValue],
+            ) -> Result<JSValue, JSException> = #function_name;
+            let result = func(&__ctx, __function, __this_object, __arguments.as_slice());
+
+            mem::forget(__ctx);
+
+            match result {
+                Ok(value) => value.into(),
+                Err(exception) => {
+                    let raw_exception: javascriptcore_sys::JSValueRef = exception.into();
+                    *__raw_exception = raw_exception as *mut _;
+
+                    ptr::null()
+                }
+            }
+        }
+    }
+    .into()
+}

--- a/src/base.rs
+++ b/src/base.rs
@@ -52,9 +52,9 @@ pub fn evaluate_script<S: Into<JSString>, U: Into<JSString>>(
         );
 
         if result.is_null() {
-            Err(JSValue::new_inner(ctx.raw, exception).into())
+            Err(JSValue::from_raw(ctx.raw, exception).into())
         } else {
-            Ok(JSValue::new_inner(ctx.raw, result))
+            Ok(JSValue::from_raw(ctx.raw, result))
         }
     }
 }
@@ -103,7 +103,7 @@ pub fn check_script_syntax<S: Into<JSString>, U: Into<JSString>>(
         if result {
             Ok(())
         } else {
-            Err(JSValue::new_inner(ctx.raw, exception).into())
+            Err(JSValue::from_raw(ctx.raw, exception).into())
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -109,10 +109,7 @@ impl JSContext {
         if global_object.is_null() {
             Err(JSValue::new_inner(self.raw, global_object).into())
         } else {
-            Ok(JSObject {
-                raw: global_object,
-                value: JSValue::new_inner(self.raw, global_object),
-            })
+            Ok(JSObject::new_inner(self.raw, global_object))
         }
     }
 }

--- a/src/contextgroup.rs
+++ b/src/contextgroup.rs
@@ -10,7 +10,7 @@ use std::ptr;
 impl JSContextGroup {
     /// Creates a JavaScript context group.
     pub fn new() -> Self {
-        JSContextGroup::default()
+        Self::default()
     }
 
     /// Creates a global JavaScript execution context in this context
@@ -22,9 +22,9 @@ impl JSContextGroup {
     ///
     /// The created global context retains this group.
     pub fn new_context(&self) -> JSContext {
-        JSContext {
-            raw: unsafe { sys::JSGlobalContextCreateInGroup(self.raw, ptr::null_mut()) },
-        }
+        JSContext::new_inner(unsafe {
+            sys::JSGlobalContextCreateInGroup(self.raw, ptr::null_mut())
+        })
     }
 
     /// Creates a global JavaScript execution context in this context
@@ -39,16 +39,16 @@ impl JSContextGroup {
     /// * `global_object_class`: The class to use when creating the global
     ///   object.
     pub fn new_context_with_class(&self, global_object_class: &JSClass) -> JSContext {
-        JSContext {
-            raw: unsafe { sys::JSGlobalContextCreateInGroup(self.raw, global_object_class.raw) },
-        }
+        JSContext::new_inner(unsafe {
+            sys::JSGlobalContextCreateInGroup(self.raw, global_object_class.raw)
+        })
     }
 }
 
 impl Default for JSContextGroup {
     /// Creates a JavaScript context group.
     fn default() -> Self {
-        JSContextGroup {
+        Self {
             raw: unsafe { sys::JSContextGroupCreate() },
         }
     }

--- a/src/contextgroup.rs
+++ b/src/contextgroup.rs
@@ -22,9 +22,7 @@ impl JSContextGroup {
     ///
     /// The created global context retains this group.
     pub fn new_context(&self) -> JSContext {
-        JSContext::new_inner(unsafe {
-            sys::JSGlobalContextCreateInGroup(self.raw, ptr::null_mut())
-        })
+        unsafe { JSContext::from_raw(sys::JSGlobalContextCreateInGroup(self.raw, ptr::null_mut())) }
     }
 
     /// Creates a global JavaScript execution context in this context
@@ -39,9 +37,12 @@ impl JSContextGroup {
     /// * `global_object_class`: The class to use when creating the global
     ///   object.
     pub fn new_context_with_class(&self, global_object_class: &JSClass) -> JSContext {
-        JSContext::new_inner(unsafe {
-            sys::JSGlobalContextCreateInGroup(self.raw, global_object_class.raw)
-        })
+        unsafe {
+            JSContext::from_raw(sys::JSGlobalContextCreateInGroup(
+                self.raw,
+                global_object_class.raw,
+            ))
+        }
     }
 }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{JSException, JSString, JSValue};
+use crate::{sys, JSException, JSString, JSValue};
 
 impl JSException {
     /// Return the underlying value backing the exception.
@@ -26,5 +26,11 @@ impl JSException {
 impl From<JSValue> for JSException {
     fn from(value: JSValue) -> Self {
         Self { value }
+    }
+}
+
+impl From<JSException> for sys::JSValueRef {
+    fn from(value: JSException) -> Self {
+        value.value.raw
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,8 @@
     unused_qualifications
 )]
 
-extern crate javascriptcore_sys as sys;
+pub use javascriptcore_macros::function_callback;
+use javascriptcore_sys as sys;
 
 mod base;
 mod class;

--- a/src/object.rs
+++ b/src/object.rs
@@ -9,10 +9,15 @@ use std::ops::Deref;
 use std::ptr;
 
 impl JSObject {
-    pub(crate) fn new_inner(ctx: sys::JSContextRef, raw: sys::JSObjectRef) -> Self {
+    /// Create a new [`Self`] from its raw pointer directly.
+    ///
+    /// # Safety
+    ///
+    /// Ensure `raw` is valid.
+    pub unsafe fn from_raw(ctx: sys::JSContextRef, raw: sys::JSObjectRef) -> Self {
         Self {
             raw,
-            value: JSValue::new_inner(ctx, raw),
+            value: JSValue::from_raw(ctx, raw),
         }
     }
 
@@ -87,7 +92,7 @@ impl JSObject {
             sys::JSObjectGetProperty(self.value.ctx, self.raw, name.into().raw, &mut exception)
         };
 
-        JSValue::new_inner(self.value.ctx, value)
+        unsafe { JSValue::from_raw(self.value.ctx, value) }
     }
 
     /// Gets a property from an object by numeric index.
@@ -136,7 +141,7 @@ impl JSObject {
             sys::JSObjectGetPropertyAtIndex(self.value.ctx, self.raw, index, &mut exception)
         };
 
-        JSValue::new_inner(self.value.ctx, value)
+        unsafe { JSValue::from_raw(self.value.ctx, value) }
     }
 
     /// Set a property onto an object.
@@ -174,7 +179,7 @@ impl JSObject {
         }
 
         if !exception.is_null() {
-            return Err(JSValue::new_inner(context, exception).into());
+            return Err(unsafe { JSValue::from_raw(context, exception) }.into());
         }
 
         Ok(())
@@ -209,7 +214,7 @@ impl JSObject {
         }
 
         if !exception.is_null() {
-            return Err(JSValue::new_inner(context, exception).into());
+            return Err(unsafe { JSValue::from_raw(context, exception) }.into());
         }
 
         Ok(())
@@ -247,7 +252,7 @@ impl JSObject {
         };
 
         if !exception.is_null() {
-            return Err(JSValue::new_inner(context, exception).into());
+            return Err(unsafe { JSValue::from_raw(context, exception) }.into());
         }
 
         if result.is_null() {
@@ -258,7 +263,7 @@ impl JSObject {
             .into());
         }
 
-        Ok(JSValue::new_inner(context, result))
+        Ok(unsafe { JSValue::from_raw(context, result) })
     }
 
     /// Call this object considering it is a valid function.
@@ -301,7 +306,7 @@ impl JSObject {
         };
 
         if !exception.is_null() {
-            return Err(JSValue::new_inner(context, exception).into());
+            return Err(unsafe { JSValue::from_raw(context, exception).into() });
         }
 
         if result.is_null() {
@@ -312,7 +317,7 @@ impl JSObject {
             .into());
         }
 
-        Ok(JSValue::new_inner(context, result))
+        Ok(unsafe { JSValue::from_raw(context, result) })
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -9,6 +9,13 @@ use std::ops::Deref;
 use std::ptr;
 
 impl JSObject {
+    pub(crate) fn new_inner(ctx: sys::JSContextRef, raw: sys::JSObjectRef) -> Self {
+        Self {
+            raw,
+            value: JSValue::new_inner(ctx, raw),
+        }
+    }
+
     /// Gets an iterator over the names of an object's enumerable properties.
     ///
     /// ```

--- a/src/value.rs
+++ b/src/value.rs
@@ -88,7 +88,7 @@ impl JSValue {
     /// assert!(v.is_number());
     /// ```
     pub fn new_number(ctx: &JSContext, number: f64) -> Self {
-        JSValue::new_inner(ctx.raw, unsafe { sys::JSValueMakeNumber(ctx.raw, number) })
+        Self::new_inner(ctx.raw, unsafe { sys::JSValueMakeNumber(ctx.raw, number) })
     }
 
     /// Creates a JavaScript value of the `string` type.
@@ -115,7 +115,7 @@ impl JSValue {
         ctx: *const sys::OpaqueJSContext,
         string: S,
     ) -> Self {
-        JSValue::new_inner(ctx, unsafe {
+        Self::new_inner(ctx, unsafe {
             sys::JSValueMakeString(ctx, string.into().raw)
         })
     }
@@ -136,7 +136,7 @@ impl JSValue {
     /// assert!(v.is_symbol());
     /// ```
     pub fn new_symbol<S: Into<JSString>>(ctx: &JSContext, description: S) -> Self {
-        JSValue::new_inner(ctx.raw, unsafe {
+        Self::new_inner(ctx.raw, unsafe {
             sys::JSValueMakeSymbol(ctx.raw, description.into().raw)
         })
     }
@@ -174,14 +174,14 @@ impl JSValue {
         };
 
         if !exception.is_null() {
-            return Err(JSValue::new_inner(ctx.raw, exception).into());
+            return Err(Self::new_inner(ctx.raw, exception).into());
         }
 
         if result.is_null() {
-            return Err(JSValue::new_string(ctx, "Failed to make a new array").into());
+            return Err(Self::new_string(ctx, "Failed to make a new array").into());
         }
 
-        Ok(JSValue::new_inner(ctx.raw, result))
+        Ok(Self::new_inner(ctx.raw, result))
     }
 
     /// Creates a JavaScript value of the `TypedArray` type.
@@ -236,11 +236,11 @@ impl JSValue {
         };
 
         if !exception.is_null() {
-            return Err(JSValue::new_inner(ctx.raw, exception).into());
+            return Err(Self::new_inner(ctx.raw, exception).into());
         }
 
         if result.is_null() {
-            return Err(JSValue::new_string(ctx, "Failed to make a new typed array").into());
+            return Err(Self::new_string(ctx, "Failed to make a new typed array").into());
         }
 
         Ok(JSValue::new_inner(ctx.raw, result))
@@ -268,7 +268,7 @@ impl JSValue {
         if value.is_null() {
             None
         } else {
-            Some(JSValue::new_inner(ctx.raw, value))
+            Some(Self::new_inner(ctx.raw, value))
         }
     }
 
@@ -295,7 +295,7 @@ impl JSValue {
             unsafe { sys::JSValueCreateJSONString(self.ctx, self.raw, indent, &mut exception) };
 
         if value.is_null() {
-            Err(JSValue::new_inner(self.ctx, exception).into())
+            Err(Self::new_inner(self.ctx, exception).into())
         } else {
             Ok(JSString { raw: value })
         }
@@ -496,7 +496,7 @@ impl JSValue {
         let number = unsafe { sys::JSValueToNumber(self.ctx, self.raw, &mut exception) };
 
         if number.is_nan() {
-            Err(JSValue::new_inner(self.ctx, exception).into())
+            Err(Self::new_inner(self.ctx, exception).into())
         } else {
             Ok(number)
         }
@@ -520,7 +520,7 @@ impl JSValue {
         let string = unsafe { sys::JSValueToStringCopy(self.ctx, self.raw, &mut exception) };
 
         if string.is_null() {
-            Err(JSValue::new_inner(self.ctx, exception).into())
+            Err(Self::new_inner(self.ctx, exception).into())
         } else {
             Ok(JSString { raw: string })
         }
@@ -544,7 +544,7 @@ impl JSValue {
         let object = unsafe { sys::JSValueToObject(self.ctx, self.raw, &mut exception) };
 
         if object.is_null() {
-            Err(JSValue::new_inner(self.ctx, exception).into())
+            Err(Self::new_inner(self.ctx, exception).into())
         } else {
             Ok(JSObject::new_inner(self.ctx, object))
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -549,10 +549,7 @@ impl JSValue {
         if object.is_null() {
             Err(JSValue::new_inner(self.ctx, exception).into())
         } else {
-            Ok(JSObject {
-                raw: object,
-                value: JSValue::new_inner(self.ctx, self.raw),
-            })
+            Ok(JSObject::new_inner(self.ctx, object))
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -9,10 +9,7 @@ use std::ptr;
 
 impl JSValue {
     /// Create a [`Self`].
-    pub(crate) fn new_inner(
-        ctx: *const sys::OpaqueJSContext,
-        raw: *const sys::OpaqueJSValue,
-    ) -> Self {
+    pub(crate) fn new_inner(ctx: sys::JSContextRef, raw: sys::JSValueRef) -> Self {
         Self { ctx, raw }
     }
 


### PR DESCRIPTION
This PR is twofold: first it creates `JSValue::new_function`, second it creates a procedural macro named `function_callback` to create function callbacks more easily.

Check out this test:

```rust
#[test]
fn function_with_macros() -> Result<(), JSException> {
    use crate as javascriptcore;
    use crate::function_callback;

    let ctx = JSContext::default();

    #[function_callback]
    fn sum(
        ctx: &JSContext,
        _function: Option<&JSObject>,
        _this_object: Option<&JSObject>,
        arguments: &[JSValue],
    ) -> Result<JSValue, JSException> {
        if arguments.len() != 2 {
            return Err(JSValue::new_string(ctx, "must receive 2 arguments").into());
        }

        let x = arguments[0].as_number()?;
        let y = arguments[1].as_number()?;

        Ok(JSValue::new_number(ctx, x + y))
    }

    let sum = JSValue::new_function(&ctx, "awesome_sum", Some(sum)).as_object()?;

    // Correct call.
    {
        let result = sum.call_as_function(
            None,
            &[JSValue::new_number(&ctx, 1.), JSValue::new_number(&ctx, 2.)],
        )?;

        assert_eq!(result.as_number()?, 3.);
    }

    // Invalid call: Not enough arguments.
    {
        let result = sum.call_as_function(None, &[]);

        assert!(result.is_err());
    }

    Ok(())
}
```