### PR TITLE
feat: Improve the `function_callback` procedural macro

### DIFF
--- a/javascriptcore-macros/src/lib.rs
+++ b/javascriptcore-macros/src/lib.rs
@@ -1,6 +1,22 @@
 use proc_macro::TokenStream;
 use quote::quote;
 
+/// Transforms a Rust function into a C function for being used as a JavaScript callback.
+///
+/// This `function_callback` procedural macro transforms a Rust function of type:
+///
+/// ```rust,ignore
+/// fn(
+///     context: &JSContext,
+///     function: Option<&JSObject>,
+///     this_object: Option<&JSObject>,
+///     arguments: &[JSValue]
+/// ) -> Result<JSValue, JSException>
+/// ```
+///
+/// into a `javascriptcore_sys::JSObjectCallAsFunctionCallback` function.
+///
+/// Check the documentation of `javascriptcore::JSValue::new_function` to learn more.
 #[proc_macro_attribute]
 pub fn function_callback(_attributes: TokenStream, item: TokenStream) -> TokenStream {
     let function = syn::parse::<syn::ItemFn>(item)
@@ -9,59 +25,82 @@ pub fn function_callback(_attributes: TokenStream, item: TokenStream) -> TokenSt
 
     quote! {
         unsafe extern "C" fn #function_name(
-            __raw_ctx: javascriptcore_sys::JSContextRef,
-            __raw_function: javascriptcore_sys::JSObjectRef,
-            __raw_this_object: javascriptcore_sys::JSObjectRef,
-            __raw_argument_count: usize,
-            __raw_arguments: *const javascriptcore_sys::JSValueRef,
-            __raw_exception: *mut javascriptcore_sys::JSValueRef,
+            raw_ctx: javascriptcore_sys::JSContextRef,
+            function: javascriptcore_sys::JSObjectRef,
+            this_object: javascriptcore_sys::JSObjectRef,
+            argument_count: usize,
+            arguments: *const javascriptcore_sys::JSValueRef,
+            exception: *mut javascriptcore_sys::JSValueRef,
         ) -> *const javascriptcore_sys::OpaqueJSValue {
-            use core::{mem, ptr, slice};
+            use core::{mem::ManuallyDrop, ptr, slice};
             use javascriptcore::{JSContext, JSObject, JSValue};
+            use javascriptcore_sys::JSValueRef;
 
-            let __ctx = JSContext::from_raw(__raw_ctx as *mut _);
-            let __function = JSObject::from_raw(__raw_ctx, __raw_function);
-            let __this_object = JSObject::from_raw(__raw_ctx, __raw_this_object);
+            // This should never happen, it's simply a paranoid precaution.
+            if raw_ctx.is_null() {
+                return ptr::null();
+            }
 
-            let __function = if __raw_function.is_null() {
+            // First off, let's prepare the arguments. The goal is to transform the raw C pointers
+            // into Rust types.
+
+            // Let's not drop `ctx`, otherwise it will close the context.
+            let ctx = ManuallyDrop::new(JSContext::from_raw(raw_ctx as *mut _));
+            let function = JSObject::from_raw(raw_ctx, function);
+            let this_object = JSObject::from_raw(raw_ctx, this_object);
+
+            let function = if function.is_null() {
                 None
             } else {
-                Some(&__function)
+                Some(&function)
             };
 
-            let __this_object = if __raw_this_object.is_null() {
+            let this_object = if this_object.is_null() {
                 None
             } else {
-                Some(&__this_object)
+                Some(&this_object)
             };
 
-            let __arguments = if __raw_argument_count == 0 {
+            let arguments = if argument_count == 0 || arguments.is_null() {
                 Vec::new()
             } else {
-                unsafe { slice::from_raw_parts(__raw_arguments, __raw_argument_count) }
+                unsafe { slice::from_raw_parts(arguments, argument_count) }
                     .iter()
-                    .map(|value| JSValue::from_raw(__raw_ctx, *value))
+                    .map(|value| JSValue::from_raw(raw_ctx, *value))
                     .collect::<Vec<_>>()
             };
 
-            #function
-
+            // Isolate the `#function` inside its own block to avoid collisions with variables.
+            // Let's use also this as an opportunity to type check the function being annotated by
+            // `function_callback`.
             let func: fn(
                 &JSContext,
                 Option<&JSObject>,
                 Option<&JSObject>,
-                arguments: &[JSValue],
-            ) -> Result<JSValue, JSException> = #function_name;
-            let result = func(&__ctx, __function, __this_object, __arguments.as_slice());
+                &[JSValue],
+            ) -> Result<JSValue, JSException> = {
+                #function
 
-            mem::forget(__ctx);
+                #function_name
+            };
 
+            // Second, call the original function.
+            let result = func(&ctx, function, this_object, arguments.as_slice());
+
+            // Finally, let's handle the result, including the exception.
             match result {
-                Ok(value) => value.into(),
-                Err(exception) => {
-                    let raw_exception: javascriptcore_sys::JSValueRef = exception.into();
-                    *__raw_exception = raw_exception as *mut _;
+                Ok(value) => {
+                    // Ensure `exception` contains a null pointer.
+                    *exception = ptr::null_mut();
 
+                    // Return the result.
+                    value.into()
+                }
+                Err(exc) => {
+                    // Fill the exception.
+                    *exception = JSValueRef::from(exc) as *mut _;
+
+                    // Return a null pointer for the result.
                     ptr::null()
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@ pub struct JSString {
 /// * [`JSValue::new_boolean()`]
 /// * [`JSValue::new_number()`]
 /// * [`JSValue::new_string()`]
+/// * [`JSValue::new_typed_array_with_bytes()`]
+/// * [`JSValue::new_function()`]
 /// * [`JSValue::new_from_json()`]
 ///
 /// # JSON


### PR DESCRIPTION
First off, `#function` is moved inside its own block, thus removing
possible naming collisions with other variables.

Second, all `__raw_*` and `__` prefixes on variable names are removed.

Third, `ManuallyDrop` is used instead of using `mem::forget`.

Fourth, `raw_ctx` is checked to not be null.

Fiveth, `arguments` is checked to not be null.

Finally, a documentation is added.

Edit: another patch improves the doc of `JSValue` by the way.