### PR TITLE
fix: `#[function_callback]` can be used without `javascriptcore_sys`

### DIFF
--- a/javascriptcore-macros/src/lib.rs
+++ b/javascriptcore-macros/src/lib.rs
@@ -25,16 +25,15 @@ pub fn function_callback(_attributes: TokenStream, item: TokenStream) -> TokenSt
 
     quote! {
         unsafe extern "C" fn #function_name(
-            raw_ctx: javascriptcore_sys::JSContextRef,
-            function: javascriptcore_sys::JSObjectRef,
-            this_object: javascriptcore_sys::JSObjectRef,
+            raw_ctx: javascriptcore::sys::JSContextRef,
+            function: javascriptcore::sys::JSObjectRef,
+            this_object: javascriptcore::sys::JSObjectRef,
             argument_count: usize,
-            arguments: *const javascriptcore_sys::JSValueRef,
-            exception: *mut javascriptcore_sys::JSValueRef,
-        ) -> *const javascriptcore_sys::OpaqueJSValue {
+            arguments: *const javascriptcore::sys::JSValueRef,
+            exception: *mut javascriptcore::sys::JSValueRef,
+        ) -> *const javascriptcore::sys::OpaqueJSValue {
             use core::{mem::ManuallyDrop, ptr, slice};
-            use javascriptcore::{JSContext, JSObject, JSValue};
-            use javascriptcore_sys::JSValueRef;
+            use javascriptcore::{sys::JSValueRef, JSContext, JSObject, JSValue};
 
             // This should never happen, it's simply a paranoid precaution.
             if raw_ctx.is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@
 )]
 
 pub use javascriptcore_macros::function_callback;
-use javascriptcore_sys as sys;
+#[doc(hidden)]
+pub use javascriptcore_sys as sys;
 
 mod base;
 mod class;


### PR DESCRIPTION
This patch fixes the `#[function_callback]` procedural macro. It was using types from `javascriptcore` and from `javascriptcore_sys`. Problem: if the user uses `javascriptcore` only, and wants to use the macro, it has to add `javascriptcore_sys` as a dependency.

To avoid this situation, we expose `javascript_sys` as a (doc hidden) module from `javascript` under the `sys` name.

This patch also updates the `#[function_callback]` to use `javascriptcore::sys` instead of `javascriptcore`, and we are good.