### PR TITLE
feat: Improve `JSClass` and add `JSClassBuilder`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ exclude = ["javascript_core/**"]
 [dependencies]
 javascriptcore-macros = { path = "javascriptcore-macros", version = "0.0.1" }
 javascriptcore-sys = { path = "javascriptcore-sys", version = "0.0.5" }
+thiserror = "1.0.49"

--- a/src/class.rs
+++ b/src/class.rs
@@ -4,10 +4,143 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{sys, JSClass};
+use std::{ffi::CString, ptr};
+
+use sys::{
+    JSClassCreate, JSClassDefinition, JSClassRetain, JSObjectCallAsConstructorCallback,
+    JSObjectMake,
+};
+
+use crate::{sys, JSClass, JSContext, JSObject};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum JSClassError {
+    #[error("classname was invalid (e.g. it contains a NULL character)")]
+    InvalidName,
+
+    #[error("class could not be created")]
+    FailedToCreateClass,
+
+    #[error("class could not be retained")]
+    FailedToRetainClass,
+}
+
+impl JSClass {
+    pub fn new<N>(
+        name: N,
+        constructor: JSObjectCallAsConstructorCallback,
+    ) -> Result<Self, JSClassError>
+    where
+        N: Into<Vec<u8>>,
+    {
+        let Ok(name) = CString::new(name) else {
+            return Err(JSClassError::InvalidName);
+        };
+
+        let class_definition = JSClassDefinition {
+            className: name.as_ptr(),
+            callAsConstructor: constructor,
+            ..Default::default()
+        };
+
+        let class = unsafe { JSClassCreate(&class_definition) };
+
+        if class.is_null() {
+            return Err(JSClassError::FailedToCreateClass);
+        }
+
+        let class = unsafe { JSClassRetain(class) };
+
+        if class.is_null() {
+            return Err(JSClassError::FailedToRetainClass);
+        }
+
+        Ok(unsafe { JSClass::from_raw(class, name) })
+    }
+
+    /// Create a new [`Self`] from its raw pointer directly.
+    ///
+    /// # Safety
+    ///
+    /// Ensure `raw` is valid.
+    unsafe fn from_raw(raw: sys::JSClassRef, name: CString) -> Self {
+        Self { raw, name }
+    }
+
+    pub fn instantiate(&self, ctx: &JSContext) -> JSObject {
+        unsafe { JSObject::from_raw(ctx.raw, JSObjectMake(ctx.raw, self.raw, ptr::null_mut())) }
+    }
+}
 
 impl Drop for JSClass {
     fn drop(&mut self) {
         unsafe { sys::JSClassRelease(self.raw) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{constructor_callback, function_callback, JSException};
+
+    use super::*;
+
+    #[test]
+    fn class_with_no_constructor() -> Result<(), JSException> {
+        let ctx = JSContext::default();
+        let class = JSClass::new("Foo", None).unwrap();
+        let object = class.instantiate(&ctx);
+
+        assert!(object.is_object_of_class(&class));
+
+        // It's failing because there is no constructor.
+        assert!(object.call_as_constructor(&[]).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn class_with_constructor() -> Result<(), JSException> {
+        use crate as javascriptcore;
+
+        #[constructor_callback]
+        fn foo_ctor(
+            ctx: &JSContext,
+            constructor: &JSObject,
+            _arguments: &[JSValue],
+        ) -> Result<JSValue, JSException> {
+            #[function_callback]
+            fn bar(
+                ctx: &JSContext,
+                _function: Option<&JSObject>,
+                _this_object: Option<&JSObject>,
+                _arguments: &[JSValue],
+            ) -> Result<JSValue, JSException> {
+                Ok(JSValue::new_number(&ctx, 42.))
+            }
+
+            constructor.set_property("bar", JSValue::new_function(ctx, "bar", Some(bar)))?;
+
+            Ok(constructor.into())
+        }
+
+        let ctx = JSContext::default();
+        let class = JSClass::new("Foo", Some(foo_ctor)).unwrap();
+        let object = class.instantiate(&ctx);
+
+        assert!(object.is_object_of_class(&class));
+
+        let object = object.call_as_constructor(&[])?.as_object()?;
+
+        assert_eq!(
+            object
+                .get_property("bar")
+                .as_object()?
+                .call_as_function(None, &[])?
+                .as_number()?,
+            42.
+        );
+
+        Ok(())
     }
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -4,6 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::{error, fmt};
+
 use crate::{sys, JSException, JSString, JSValue};
 
 impl JSException {
@@ -15,13 +17,20 @@ impl JSException {
     /// Return the name of the exception. This is the value of the `name`
     /// property on the exception object.
     pub fn name(&self) -> Result<JSString, JSException> {
-        self.value
-            .as_object()
-            .unwrap()
-            .get_property("name")
-            .as_string()
+        self.value.as_object()?.get_property("name").as_string()
     }
 }
+
+impl fmt::Display for JSException {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.underlying_value().as_string() {
+            Ok(string) => write!(formatter, "JSException (interpreted as string): {}", string),
+            Err(_) => write!(formatter, "{:?}", self),
+        }
+    }
+}
+
+impl error::Error for JSException {}
 
 impl From<JSValue> for JSException {
     fn from(value: JSValue) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@
     unused_qualifications
 )]
 
-pub use javascriptcore_macros::function_callback;
+use std::ffi::CString;
+
+pub use javascriptcore_macros::{constructor_callback, function_callback};
 #[doc(hidden)]
 pub use javascriptcore_sys as sys;
 
@@ -41,6 +43,8 @@ pub use crate::sys::{JSType, JSTypedArrayType};
 /// TODO: Fix `JSObjectMake` reference once it has been wrapped.
 pub struct JSClass {
     raw: sys::JSClassRef,
+    #[allow(unused)]
+    name: CString,
 }
 
 /// A JavaScript execution context.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,16 +32,17 @@ mod object;
 mod string;
 mod value;
 
-pub use crate::base::{check_script_syntax, evaluate_script, garbage_collect};
 pub use crate::sys::{JSType, JSTypedArrayType};
+pub use crate::{
+    base::{check_script_syntax, evaluate_script, garbage_collect},
+    class::JSClassBuilder,
+};
 
 /// A JavaScript class.
 ///
-/// Used with `JSObjectMake` to construct objects with custom
-/// behavior.
-///
-/// TODO: Fix `JSObjectMake` reference once it has been wrapped.
+/// The best way to create a class is by using [`JSClass::builder`].
 pub struct JSClass {
+    ctx: sys::JSContextRef,
     raw: sys::JSClassRef,
     #[allow(unused)]
     name: CString,

--- a/src/object.rs
+++ b/src/object.rs
@@ -347,6 +347,12 @@ impl From<&JSObject> for JSValue {
     }
 }
 
+impl From<JSObject> for JSValue {
+    fn from(object: JSObject) -> Self {
+        (&object).into()
+    }
+}
+
 pub struct JSObjectPropertyNameIter {
     raw: sys::JSPropertyNameArrayRef,
     idx: usize,

--- a/src/object.rs
+++ b/src/object.rs
@@ -175,7 +175,14 @@ impl JSObject {
         let context = self.value.ctx;
 
         unsafe {
-            sys::JSObjectSetProperty(context, self.raw, name.raw, value.raw, 0, &mut exception)
+            sys::JSObjectSetProperty(
+                context,
+                self.raw,
+                name.raw,
+                value.raw,
+                sys::kJSPropertyAttributeNone,
+                &mut exception,
+            )
         }
 
         if !exception.is_null() {

--- a/src/object.rs
+++ b/src/object.rs
@@ -333,6 +333,13 @@ impl Deref for JSObject {
     }
 }
 
+impl From<&JSObject> for JSValue {
+    fn from(object: &JSObject) -> Self {
+        // SAFETY: `ctx` and `raw` is valid, it's safe to use them.
+        unsafe { JSValue::from_raw(object.value.ctx, object.value.raw) }
+    }
+}
+
 pub struct JSObjectPropertyNameIter {
     raw: sys::JSPropertyNameArrayRef,
     idx: usize,

--- a/src/value.rs
+++ b/src/value.rs
@@ -667,7 +667,7 @@ impl From<JSValue> for sys::JSValueRef {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sys, JSContext, JSException, JSType, JSValue};
+    use crate::{function_callback, sys, JSContext, JSException, JSType, JSValue};
 
     #[test]
     fn strict_equality() {
@@ -866,7 +866,6 @@ mod tests {
     #[test]
     fn function_with_macros() -> Result<(), JSException> {
         use crate as javascriptcore;
-        use crate::function_callback;
 
         let ctx = JSContext::default();
 


### PR DESCRIPTION
This PR should be reviewed commit-by-commit.

Basically:
* it adds a new procedural macro: `#[constructor_callback]`
* it adds a new type `JSClassBuilder`
* it adds `JSClass::builder` and `JSClass::new_object`.

So far, `JSClassBuilder` only allows to set the class name and the class constructor, but this pattern is easily extendable to cover all features provided by `sys::JSClassDefinition`.